### PR TITLE
Add day 2 doc block comments

### DIFF
--- a/pubs/_data/eleventyComputed.js
+++ b/pubs/_data/eleventyComputed.js
@@ -14,7 +14,7 @@ async function buildDay(file, day, posts) {
     const links = {
         Puzzle: puzzleURL,
         ...(injectWriteUpUrl(day, posts)),
-        Documentation: `./advent_of_code_2022/day_${day}/index.html`,
+        Documentation: `/advent_of_code_2022/day_${day}/index.html`,
         Source: `https://github.com/kamioftea/advent-of-code-2022/blob/main/src/day_${day}.rs`
     }
 

--- a/pubs/_includes/layout.njk
+++ b/pubs/_includes/layout.njk
@@ -48,9 +48,9 @@
 				<div class="other-links">
 					<p>Related content:</p>
 					<ul>
-						{% for label, url in solutions[day - 1].links %}
+						{% for label, href in solutions[day - 1].links %}
 							{% if label != 'Write Up' %}
-								<li><a href="{{ url }}">{{ label }}</a></li>
+								<li><a href="{{ href | url }}">{{ label }}</a></li>
 							{% endif %}
 						{% endfor %}
 					</ul>

--- a/pubs/blog/day_2.md
+++ b/pubs/blog/day_2.md
@@ -47,7 +47,7 @@ fn parse_strategy(strategy: &String) -> Tournament {
 }
 
 fn parse_line(line: &str) -> Round {
-    let (part_1, part_2) = line.split_at(1);
+    let (part_1, part_2) = line.split_once(' ').unwrap();
     (
         parse_move(part_1).unwrap(),
         parse_move(part_2).unwrap()
@@ -56,9 +56,9 @@ fn parse_line(line: &str) -> Round {
 
 fn parse_move(chr: &str) -> Option<Move> {
     match chr {
-        "A" | " X" => Some(Rock),
-        "B" | " Y" => Some(Paper),
-        "C" | " Z" => Some(Scissors),
+        "A" | "X" => Some(Rock),
+        "B" | "Y" => Some(Paper),
+        "C" | "Z" => Some(Scissors),
         _ => None
     }
 }
@@ -209,9 +209,9 @@ enum Outcome {
 
 fn parse_outcome(chr: &str) -> Option<Outcome> {
     match chr {
-        " X" => Some(Loss),
-        " Y" => Some(Draw),
-        " Z" => Some(Win),
+        "X" => Some(Loss),
+        "Y" => Some(Draw),
+        "Z" => Some(Win),
         _ => None
     }
 }
@@ -257,7 +257,7 @@ tests and puzzle runner can be updated.
 
 ```rust
 fn parse_outcome_line(line: &str) -> Round {
-    let (part_1, part_2) = line.split_at(1);
+    let (part_1, part_2) = line.split_once(' ').unwrap();
     resolve_outcome(
         parse_move(part_1).unwrap(),
         parse_outcome(part_2).unwrap(),

--- a/src/day_2.rs
+++ b/src/day_2.rs
@@ -1,11 +1,13 @@
 //! This is my solution for [Advent of Code - Day 2 - _Rock Paper Scissors_](https://adventofcode.com/2022/day/2)
 //!
-//!
+//! The task was to interpret a strategy guide for a rock, paper, scissors tournament in two different ways,
+//! calculating a final score if the guide is followed.
 
 use std::fs;
 use crate::day_2::Move::{Paper, Rock, Scissors};
 use crate::day_2::Outcome::{Draw, Loss, Win};
 
+/// Encodes the possible moves a player can make
 #[derive(Eq, PartialEq, Debug, Clone, Copy)]
 enum Move {
     Rock,
@@ -13,14 +15,17 @@ enum Move {
     Scissors,
 }
 
+/// Encodes the possible outcome of a round
 #[derive(Eq, PartialEq, Debug)]
 enum Outcome {
     Win,
     Loss,
     Draw,
 }
-
+/// A round representing `(opponent's move, my move)`
 type Round = (Move, Move);
+
+/// My view of a tournament: all the rounds I participate in
 type Tournament = Vec<Round>;
 
 /// The entry point for running the solutions with the 'real' puzzle input.
@@ -44,46 +49,53 @@ pub fn run() {
     );
 }
 
+/// Parse a strategy guide, taking the syntax that maps a line in the guide to a `Round` played so this can be reused
+/// in both parts.
 fn parse_strategy(strategy: &String, syntax: fn(&str) -> Round) -> Tournament {
     strategy.lines()
             .map(syntax)
             .collect()
 }
 
+/// The line syntax for part 1
 fn parse_moves_line(line: &str) -> Round {
-    let (part_1, part_2) = line.split_at(1);
+    let (part_1, part_2) = line.split_once(' ').unwrap();
     (
         parse_move(part_1).unwrap(),
         parse_move(part_2).unwrap()
     )
 }
 
+/// The kine syntax for part 2
 fn parse_outcome_line(line: &str) -> Round {
-    let (part_1, part_2) = line.split_at(1);
+    let (part_1, part_2) = line.split_once(' ').unwrap();
     resolve_outcome(
         parse_move(part_1).unwrap(),
         parse_outcome(part_2).unwrap(),
     )
 }
 
+/// Parse a part of an input line as a move
 fn parse_move(chr: &str) -> Option<Move> {
     match chr {
-        "A" | " X" => Some(Rock),
-        "B" | " Y" => Some(Paper),
-        "C" | " Z" => Some(Scissors),
+        "A" | "X" => Some(Rock),
+        "B" | "Y" => Some(Paper),
+        "C" | "Z" => Some(Scissors),
         _ => None
     }
 }
 
+/// Parse part of an input line as and expected outcome for a round
 fn parse_outcome(chr: &str) -> Option<Outcome> {
     match chr {
-        " X" => Some(Loss),
-        " Y" => Some(Draw),
-        " Z" => Some(Win),
+        "X" => Some(Loss),
+        "Y" => Some(Draw),
+        "Z" => Some(Win),
         _ => None
     }
 }
 
+/// Calculate the move to make given my opponent's expected move and a desired outcome
 fn resolve_outcome(their_move: Move, outcome: Outcome) -> Round {
     let my_move = match outcome {
         Loss => loss_for(their_move),
@@ -94,18 +106,7 @@ fn resolve_outcome(their_move: Move, outcome: Outcome) -> Round {
     (their_move, my_move)
 }
 
-fn score_round(round: &Round) -> u32 {
-    score_result(round) + score_move(round)
-}
-
-fn score_result(round: &Round) -> u32 {
-    match round {
-        &(their_move, my_move) if win_for(their_move) == my_move => 6,
-        &(their_move, my_move) if draw_for(their_move) == my_move => 3,
-        (_, _) => 0
-    }
-}
-
+/// Given an expected move, what move should be thrown to win a round
 fn win_for(mv: Move) -> Move {
     match mv {
         Rock => Paper,
@@ -114,10 +115,12 @@ fn win_for(mv: Move) -> Move {
     }
 }
 
+/// Given an expected move, what move should be thrown to draw a round
 fn draw_for(mv: Move) -> Move {
     mv
 }
 
+/// Given an expected move, what move should be thrown to win a round
 fn loss_for(mv: Move) -> Move {
     match mv {
         Rock => Scissors,
@@ -126,6 +129,12 @@ fn loss_for(mv: Move) -> Move {
     }
 }
 
+/// Calculate the score for a single round
+fn score_round(round: &Round) -> u32 {
+    score_result(round) + score_move(round)
+}
+
+/// Calculate the part of a round score based on the move I threw
 fn score_move((_, my_move): &Round) -> u32 {
     match my_move {
         Rock => 1,
@@ -134,6 +143,16 @@ fn score_move((_, my_move): &Round) -> u32 {
     }
 }
 
+/// Calculate the part of a round score based on the round's outcome
+fn score_result(round: &Round) -> u32 {
+    match round {
+        &(their_move, my_move) if win_for(their_move) == my_move => 6,
+        &(their_move, my_move) if draw_for(their_move) == my_move => 3,
+        (_, _) => 0
+    }
+}
+
+/// Calculate the sum of the scores for all rounds I layed in
 fn score_tournament(tournament: &Tournament) -> u32 {
     tournament.into_iter().map(score_round).sum()
 }


### PR DESCRIPTION
- Add one line doc block comments to day 2 so that they show in documentation pages
- Related content links needed url filter and to be absolute
- Use split_once rather than split_at